### PR TITLE
Change: rename Transition to BeforeAfter; deprecate Transition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "map-api"
 description = "Raft state machine"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["Databend Authors <opensource@datafuselabs.com>"]
 license = "Apache-2.0"
 edition = "2021"

--- a/src/impls/level.rs
+++ b/src/impls/level.rs
@@ -25,13 +25,13 @@ use std::ops::RangeBounds;
 use futures_util::StreamExt;
 use log::warn;
 
+use crate::BeforeAfter;
 use crate::KVResultStream;
 use crate::MapApi;
 use crate::MapApiRO;
 use crate::MapKey;
 use crate::Marked;
 use crate::MarkedOf;
-use crate::Transition;
 
 /// A simple in-memory implementation of the Map API using a BTreeMap.
 ///
@@ -129,7 +129,7 @@ where M: Clone + Unpin + Send + Sync + 'static
         &mut self,
         key: String,
         value: Option<(<String as MapKey<M>>::V, Option<M>)>,
-    ) -> Result<Transition<MarkedOf<String, M>>, io::Error> {
+    ) -> Result<BeforeAfter<MarkedOf<String, M>>, io::Error> {
         // The chance it is the bottom level is very low in a loaded system.
         // Thus, we always tombstone the key if it is None.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,9 +84,17 @@ pub use crate::map_key::MapKey;
 pub use crate::map_value::MapValue;
 pub use crate::marked::Marked;
 
+#[deprecated(since = "0.2.0", note = "Use `BeforeAfter` instead")]
+pub type Transition<T> = BeforeAfter<T>;
+
 /// Represents a transition from one state to another.
-/// The tuple contains the initial state and the resulting state.
-pub type Transition<T> = (T, T);
+///
+/// This type is a tuple containing two elements:
+/// - The first element represents the state before the transition (initial state)
+/// - The second element represents the state after the transition (resulting state)
+///
+/// It's commonly used to track changes in values or system states.
+pub type BeforeAfter<T> = (T, T);
 
 /// A boxed stream that yields `Result` of key-value pairs or an `io::Error`.
 /// The stream is 'static to ensure it can live for the entire duration of the program.

--- a/src/map_api.rs
+++ b/src/map_api.rs
@@ -22,7 +22,7 @@ use std::io;
 
 use crate::map_api_ro::MapApiRO;
 use crate::map_key::MapKey;
-use crate::Transition;
+use crate::BeforeAfter;
 
 /// Provides a read-write key-value map API, used to access state machine data.
 ///
@@ -80,7 +80,7 @@ where
     ///
     /// # Returns
     ///
-    /// A [`Transition`] containing:
+    /// A [`BeforeAfter`] containing:
     /// - The old value (before the operation)
     /// - The new value (after the operation)
     ///
@@ -92,5 +92,5 @@ where
         &mut self,
         key: K,
         value: Option<(K::V, Option<M>)>,
-    ) -> Result<Transition<crate::MarkedOf<K, M>>, io::Error>;
+    ) -> Result<BeforeAfter<crate::MarkedOf<K, M>>, io::Error>;
 }

--- a/src/seq_value/mod.rs
+++ b/src/seq_value/mod.rs
@@ -24,4 +24,7 @@ mod update;
 
 pub use seq_value_trait::SeqValue;
 pub use seqv::SeqV;
-pub use update::Update;
+pub use update::Change;
+
+#[deprecated(since = "0.2.0", note = "Use `Change` instead")]
+pub type Update<M, V = Vec<u8>> = Change<M, V>;

--- a/src/seq_value/update.rs
+++ b/src/seq_value/update.rs
@@ -16,13 +16,13 @@ use crate::seq_value::SeqV;
 
 /// An update event for a key.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Update<M, V = Vec<u8>> {
+pub struct Change<M, V = Vec<u8>> {
     pub key: String,
     pub before: Option<SeqV<M, V>>,
     pub after: Option<SeqV<M, V>>,
 }
 
-impl<M, V> Update<M, V> {
+impl<M, V> Change<M, V> {
     pub fn new(key: String, before: Option<SeqV<M, V>>, after: Option<SeqV<M, V>>) -> Self {
         Self { key, before, after }
     }


### PR DESCRIPTION

## Changelog

##### Change: rename Transition to BeforeAfter; deprecate Transition

##### Change: rename Update to Change and deprecate Update

##### BumpVer: 0.2.0

---